### PR TITLE
Enable ping in Mariner image during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -478,6 +478,11 @@ if [ -n "$BFCFG" ]; then
 	$BFCFG
 fi
 
+# Enable ping
+iptables -P INPUT ACCEPT
+iptables -P OUTPUT ACCEPT
+iptables -P FORWARD ACCEPT
+
 echo
 echo "User/password is \"mariner/mariner\""
 echo


### PR DESCRIPTION
Enable ping in Mariner image during install for testing purposes.