### PR TITLE
Adding support for Bluefield 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,21 +10,24 @@ ADD rebuild_drivers /tmp
 ENV RUN_FW_UPDATER=no
 
 RUN yum install -y dnf-utils sed libtool
-RUN yum-config-manager --nogpgcheck --add-repo https://linux.mellanox.com/public/repo/doca/2.0.2/mariner2.0/aarch64/
-RUN sed -i -e "s/linux.mellanox.com_public_repo_doca_2.0.2_mariner2.0_aarch64_/doca/" /etc/yum.repos.d/linux.mellanox.com_public_repo_doca_2.0.2_mariner2.0_aarch64_.repo
+RUN yum-config-manager --nogpgcheck --add-repo https://linux.mellanox.com/public/repo/doca/2.2.0/mariner2.0/aarch64/
+RUN sed -i -e "s/linux.mellanox.com_public_repo_doca_2.2.0_mariner2.0_aarch64_/doca/" /etc/yum.repos.d/linux.mellanox.com_public_repo_doca_2.2.0_mariner2.0_aarch64_.repo
 RUN yum-config-manager --save --setopt=doca.sslverify=0 doca
 RUN yum-config-manager --save --setopt=doca.gpgcheck=0 doca
 RUN yum-config-manager --dump doca
 
 
-RUN for app in wget util-linux netplan openssh-server iproute which git selinux-policy-devel diffutils file procps-ng patch rpm-build kernel kernel-devel kernel-headers libreswan python3-devel python3-test python3-Cython efibootmgr efivar grub2 grub2-efi grub2-efi-unsigned shim-unsigned-aarch64 lvm2 popt-devel bc flex bison lm_sensors ninja-build meson cryptsetup rasdaemon pciutils-devel python3-sphinx python3-six kexec-tools jq dbus libgomp iana-etc libgomp-devel libgcc-devel libgcc-atomic libmpc binutils iptables glibc-devel gcc tcl-devel automake libmnl autoconf tcl libnl3-devel openssl-devel libstdc++-devel binutils-devel libnl3 libdb-devel make libmnl-devel iptables-devel lsof desktop-file-utils doxygen cmake cmake3 libcap-ng-devel systemd-devel ncurses-devel net-tools sudo libpcap libnuma unbound vim iputils; do yum install -y $app || true; done
+# RUN for app in wget util-linux netplan openssh-server iproute which git selinux-policy-devel diffutils file procps-ng patch rpm-build kernel kernel-devel kernel-headers libreswan python3-devel python3-test python3-Cython efibootmgr efivar grub2 grub2-efi grub2-efi-unsigned shim-unsigned-aarch64 lvm2 popt-devel bc flex bison lm_sensors ninja-build meson cryptsetup rasdaemon pciutils-devel python3-sphinx python3-six kexec-tools jq dbus libgomp iana-etc libgomp-devel libgcc-devel libgcc-atomic libmpc binutils iptables glibc-devel gcc tcl-devel automake libmnl autoconf tcl libnl3-devel openssl-devel libstdc++-devel binutils-devel libnl3 libdb-devel make libmnl-devel iptables-devel lsof desktop-file-utils doxygen cmake cmake3 libcap-ng-devel systemd-devel ncurses-devel net-tools sudo libpcap libnuma unbound vim iputils; do yum install -y $app || true; done
+
+RUN yum install -y wget kmod util-linux sudo netplan hostname openssh-server iproute which git selinux-policy-devel diffutils file procps-ng patch rpm-build kernel kernel-devel kernel-headers python3 python3-devel python3-libs python3-test python3-pyelftools efibootmgr efivar grub2 grub2-efi grub2-efi-unsigned shim-unsigned-aarch64 lvm2 popt-devel bc flex bison lm_sensors ninja-build meson cryptsetup pciutils-devel python3-sphinx python3-six kexec-tools jq dbus libgomp iana-etc libgomp-devel libgcc-devel libgcc-atomic libmpc binutils libsepol-devel iptables glibc-devel gcc tcl-devel automake libmnl autoconf tcl libnl3-devel openssl-devel libstdc++-devel binutils-devel libselinux-devel libnl3 libdb-devel make libmnl-devel iptables-devel lsof glibc numactl-devel ncurses-devel systemd-devel groff libgudev libgudev-devel lsb-release popt-devel pkg-config python3-twisted libpcap unbound python3-zope-interface graphviz less iputils tcpdump sysstat qemu-kvm libvirt libguestfs-tools libreswan ipmitool nvme-cli coreutils rsyslog
+
 # Set python3.9 as a default
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 10
 
 RUN /tmp/rebuild_drivers $(/bin/ls -1 /lib/modules/ | head -1)
 RUN /usr/sbin/depmod -a $(/bin/ls -1 /lib/modules/ | head -1) || true
 
-RUN yum install -y ibacm ibutils2 infiniband-diags infiniband-diags-compat libibumad libibverbs-utils librdmacm librdmacm-utils libxpmem libxpmem-devel mft mft-oem mlnx-ethtool mlnx-fw-updater mlnx-iproute2 mlnx-libsnap mlx-regex mlxbf-bootctl mlxbf-bootimages mstflint ofed-scripts opensm opensm-devel opensm-libs opensm-static perftest rdma-core rdma-core-devel srp_daemon ucx ucx-cma ucx-devel ucx-ib ucx-knem ucx-rdmacm xpmem mlnx-tools mlnx-dpdk mlnx-dpdk-devel dpcp libvma libvma-utils python3-grpcio python3-protobuf rxp-compiler
+RUN yum install -y ibacm ibutils2 infiniband-diags infiniband-diags-compat libibumad libibverbs libibverbs-utils librdmacm librdmacm-utils libxpmem libxpmem-devel mft mft-oem mlnx-ethtool mlnx-fw-updater mlnx-iproute2 mlnx-libsnap mlx-regex mlxbf-bootctl mlxbf-bootimages mstflint ofed-scripts opensm opensm-devel opensm-libs opensm-static perftest rdma-core rdma-core-devel srp_daemon ucx ucx-cma ucx-devel ucx-ib ucx-knem ucx-rdmacm xpmem mlnx-tools mlnx-dpdk mlnx-dpdk-devel dpcp libvma libvma-utils python3-grpcio python3-protobuf rxp-compiler openvswitch openvswitch-devel python3-openvswitch openvswitch-ipsec mlxbf-bfscripts bf-release
 
 # RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location mlnx-ofa_kernel)
 # RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location mlnx-ofa_kernel-devel)
@@ -32,18 +35,18 @@ RUN yum install -y ibacm ibutils2 infiniband-diags infiniband-diags-compat libib
 # RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location mlnx-ofa_kernel-source)
 # RUN rpm -iv --nodeps mlnx-ofa_kernel*rpm
 
-RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location openvswitch)
-RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location openvswitch-devel)
-RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location python3-openvswitch)
-RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location openvswitch-ipsec)
-RUN rpm -Uv --nodeps *openvswitch*rpm
+# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location openvswitch)
+# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location openvswitch-devel)
+# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location python3-openvswitch)
+# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location openvswitch-ipsec)
+# RUN rpm -Uv --nodeps *openvswitch*rpm
 
-RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location mlxbf-bfscripts)
-RUN rpm -iv --nodeps mlxbf-bfscripts*rpm
+# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location mlxbf-bfscripts)
+# RUN rpm -iv --nodeps mlxbf-bfscripts*rpm
 
-RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location bf-release)
-RUN rpm -iv --nodeps bf-release*rpm
+# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location bf-release)
+# RUN rpm -iv --nodeps bf-release*rpm
 
-RUN /bin/rm -f *rpm
+# RUN /bin/rm -f *rpm
 
 CMD  /root/workspace/create_bfb -k $(/bin/ls -1 /lib/modules/ | head -1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #  docker build -t bfb_runtime_mariner -f Dockerfile .
-FROM --platform=linux/arm64 mcr.microsoft.com/cbl-mariner/base/core:2.0.20230526-arm64
+FROM --platform=linux/arm64 mcr.microsoft.com/cbl-mariner/base/core:2.0.20231004-arm64
 ADD qemu-aarch64-static /usr/bin/
 
 WORKDIR /root/workspace
@@ -16,10 +16,7 @@ RUN yum-config-manager --save --setopt=doca.sslverify=0 doca
 RUN yum-config-manager --save --setopt=doca.gpgcheck=0 doca
 RUN yum-config-manager --dump doca
 
-
-# RUN for app in wget util-linux netplan openssh-server iproute which git selinux-policy-devel diffutils file procps-ng patch rpm-build kernel kernel-devel kernel-headers libreswan python3-devel python3-test python3-Cython efibootmgr efivar grub2 grub2-efi grub2-efi-unsigned shim-unsigned-aarch64 lvm2 popt-devel bc flex bison lm_sensors ninja-build meson cryptsetup rasdaemon pciutils-devel python3-sphinx python3-six kexec-tools jq dbus libgomp iana-etc libgomp-devel libgcc-devel libgcc-atomic libmpc binutils iptables glibc-devel gcc tcl-devel automake libmnl autoconf tcl libnl3-devel openssl-devel libstdc++-devel binutils-devel libnl3 libdb-devel make libmnl-devel iptables-devel lsof desktop-file-utils doxygen cmake cmake3 libcap-ng-devel systemd-devel ncurses-devel net-tools sudo libpcap libnuma unbound vim iputils; do yum install -y $app || true; done
-
-RUN yum install -y wget kmod util-linux sudo netplan hostname openssh-server iproute which git selinux-policy-devel diffutils file procps-ng patch rpm-build kernel kernel-devel kernel-headers python3 python3-devel python3-libs python3-test python3-pyelftools efibootmgr efivar grub2 grub2-efi grub2-efi-unsigned shim-unsigned-aarch64 lvm2 popt-devel bc flex bison lm_sensors ninja-build meson cryptsetup pciutils-devel python3-sphinx python3-six kexec-tools jq dbus libgomp iana-etc libgomp-devel libgcc-devel libgcc-atomic libmpc binutils libsepol-devel iptables glibc-devel gcc tcl-devel automake libmnl autoconf tcl libnl3-devel openssl-devel libstdc++-devel binutils-devel libselinux-devel libnl3 libdb-devel make libmnl-devel iptables-devel lsof glibc numactl-devel ncurses-devel systemd-devel groff libgudev libgudev-devel lsb-release popt-devel pkg-config python3-twisted libpcap unbound python3-zope-interface graphviz less iputils tcpdump sysstat qemu-kvm libvirt libguestfs-tools libreswan ipmitool nvme-cli coreutils rsyslog
+RUN yum install -y wget kmod util-linux sudo net-utils netplan hostname openssh-server iproute which git selinux-policy-devel diffutils file procps-ng patch rpm-build kernel kernel-devel kernel-headers python3 python3-devel python3-libs python3-test python3-pyelftools efibootmgr efivar grub2 grub2-efi grub2-efi-unsigned shim-unsigned-aarch64 lvm2 popt-devel bc flex bison lm_sensors ninja-build meson cryptsetup pciutils-devel python3-sphinx python3-six kexec-tools jq dbus libgomp iana-etc libgomp-devel libgcc-devel libgcc-atomic libmpc binutils libsepol-devel iptables glibc-devel gcc tcl-devel automake libmnl autoconf tcl libnl3-devel openssl-devel libstdc++-devel binutils-devel libselinux-devel libnl3 libdb-devel make libmnl-devel iptables-devel lsof glibc numactl-devel ncurses-devel systemd-devel groff libgudev libgudev-devel lsb-release popt-devel pkg-config python3-twisted libpcap unbound python3-zope-interface graphviz less iputils tcpdump sysstat qemu-kvm libvirt libguestfs-tools libreswan ipmitool nvme-cli coreutils rsyslog
 
 # Set python3.9 as a default
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 10
@@ -29,24 +26,6 @@ RUN /usr/sbin/depmod -a $(/bin/ls -1 /lib/modules/ | head -1) || true
 
 RUN yum install -y ibacm ibutils2 infiniband-diags infiniband-diags-compat libibumad libibverbs libibverbs-utils librdmacm librdmacm-utils libxpmem libxpmem-devel mft mft-oem mlnx-ethtool mlnx-fw-updater mlnx-iproute2 mlnx-libsnap mlx-regex mlxbf-bootctl mlxbf-bootimages mstflint ofed-scripts opensm opensm-devel opensm-libs opensm-static perftest rdma-core rdma-core-devel srp_daemon ucx ucx-cma ucx-devel ucx-ib ucx-knem ucx-rdmacm xpmem mlnx-tools mlnx-dpdk mlnx-dpdk-devel dpcp libvma libvma-utils python3-grpcio python3-protobuf rxp-compiler openvswitch openvswitch-devel python3-openvswitch openvswitch-ipsec mlxbf-bfscripts bf-release
 
-# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location mlnx-ofa_kernel)
-# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location mlnx-ofa_kernel-devel)
-# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location mlnx-ofa_kernel-modules)
-# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location mlnx-ofa_kernel-source)
-# RUN rpm -iv --nodeps mlnx-ofa_kernel*rpm
-
-# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location openvswitch)
-# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location openvswitch-devel)
-# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location python3-openvswitch)
-# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location openvswitch-ipsec)
-# RUN rpm -Uv --nodeps *openvswitch*rpm
-
-# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location mlxbf-bfscripts)
-# RUN rpm -iv --nodeps mlxbf-bfscripts*rpm
-
-# RUN wget --no-check-certificate --no-verbose $(repoquery --nogpgcheck --location bf-release)
-# RUN rpm -iv --nodeps bf-release*rpm
-
-# RUN /bin/rm -f *rpm
+RUN /bin/rm -f *rpm
 
 CMD  /root/workspace/create_bfb -k $(/bin/ls -1 /lib/modules/ | head -1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ ADD install.sh .
 ADD create_bfb .
 ADD rebuild_drivers /tmp
 
-RUN yum install -y dnf-utils 
-RUN yum install -y sed
-RUN yum install -y libtool
+RUN yum install -y \
+    dnf-utils \
+    sed \
+    libtool
 RUN yum-config-manager --nogpgcheck --add-repo https://linux.mellanox.com/public/repo/doca/2.2.0/mariner2.0/aarch64/
 RUN sed -i -e "s/linux.mellanox.com_public_repo_doca_2.2.0_mariner2.0_aarch64_/doca/" /etc/yum.repos.d/linux.mellanox.com_public_repo_doca_2.2.0_mariner2.0_aarch64_.repo
 RUN yum-config-manager --save --setopt=doca.sslverify=0 doca
@@ -18,7 +19,6 @@ RUN yum-config-manager --dump doca
 
 RUN yum install -y \
     wget \
-    kmod \
     util-linux \
     sudo \
     netplan \
@@ -36,11 +36,12 @@ RUN yum install -y \
     kernel \
     kernel-devel \
     kernel-headers \
-    python3 \
     python3-devel \
-    python3-libs \
     python3-test \
     python3-pyelftools \
+    python3-sphinx \
+    python3-zope-interface \
+    python3-twisted \
     efibootmgr \
     efivar \
     grub2 \
@@ -48,7 +49,6 @@ RUN yum install -y \
     grub2-efi-unsigned \
     shim-unsigned-aarch64 \
     lvm2 \
-    popt-devel \
     bc \
     flex \
     bison \
@@ -57,12 +57,8 @@ RUN yum install -y \
     meson \
     cryptsetup \
     pciutils-devel \
-    python3-sphinx \
-    python3-six \
     kexec-tools \
     jq \
-    dbus \
-    libgomp \
     iana-etc \
     libgomp-devel \
     libgcc-devel \
@@ -97,12 +93,8 @@ RUN yum install -y \
     libgudev \
     libgudev-devel \
     lsb-release \
-    popt-devel \
-    pkg-config \
-    python3-twisted \
     libpcap \
     unbound \
-    python3-zope-interface \
     graphviz \
     less \
     iputils \
@@ -140,9 +132,13 @@ RUN yum install -y \
     mlnx-fw-updater \
     mlnx-iproute2 \
     mlnx-libsnap \
+    mlnx-tools \
+    mlnx-dpdk \
+    mlnx-dpdk-devel \
     mlx-regex \
     mlxbf-bootctl \
     mlxbf-bootimages \
+    mlxbf-bfscripts \
     mstflint \
     ofed-scripts \
     opensm \
@@ -160,20 +156,16 @@ RUN yum install -y \
     ucx-knem \
     ucx-rdmacm \
     xpmem \
-    mlnx-tools \
-    mlnx-dpdk \
-    mlnx-dpdk-devel \
     dpcp \
     libvma \
     libvma-utils \
     python3-grpcio \
     python3-protobuf \
+    python3-openvswitch \
     rxp-compiler \
     openvswitch \
     openvswitch-devel \
-    python3-openvswitch \
     openvswitch-ipsec \
-    mlxbf-bfscripts \
     bf-release
 
 RUN /bin/rm -f *rpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #  docker build -t bfb_runtime_mariner -f Dockerfile .
-FROM --platform=linux/arm64 mcr.microsoft.com/cbl-mariner/base/core:2.0.20231004-arm64
+FROM --platform=linux/arm64 mcr.microsoft.com/cbl-mariner/base/core:2.0.20230904-arm64
 ADD qemu-aarch64-static /usr/bin/
 
 WORKDIR /root/workspace
@@ -7,25 +7,174 @@ ADD install.sh .
 ADD create_bfb .
 ADD rebuild_drivers /tmp
 
-ENV RUN_FW_UPDATER=no
-
-RUN yum install -y dnf-utils sed libtool
+RUN yum install -y dnf-utils 
+RUN yum install -y sed
+RUN yum install -y libtool
 RUN yum-config-manager --nogpgcheck --add-repo https://linux.mellanox.com/public/repo/doca/2.2.0/mariner2.0/aarch64/
 RUN sed -i -e "s/linux.mellanox.com_public_repo_doca_2.2.0_mariner2.0_aarch64_/doca/" /etc/yum.repos.d/linux.mellanox.com_public_repo_doca_2.2.0_mariner2.0_aarch64_.repo
 RUN yum-config-manager --save --setopt=doca.sslverify=0 doca
 RUN yum-config-manager --save --setopt=doca.gpgcheck=0 doca
 RUN yum-config-manager --dump doca
 
-RUN yum install -y wget kmod util-linux sudo net-utils netplan hostname openssh-server iproute which git selinux-policy-devel diffutils file procps-ng patch rpm-build kernel kernel-devel kernel-headers python3 python3-devel python3-libs python3-test python3-pyelftools efibootmgr efivar grub2 grub2-efi grub2-efi-unsigned shim-unsigned-aarch64 lvm2 popt-devel bc flex bison lm_sensors ninja-build meson cryptsetup pciutils-devel python3-sphinx python3-six kexec-tools jq dbus libgomp iana-etc libgomp-devel libgcc-devel libgcc-atomic libmpc binutils libsepol-devel iptables glibc-devel gcc tcl-devel automake libmnl autoconf tcl libnl3-devel openssl-devel libstdc++-devel binutils-devel libselinux-devel libnl3 libdb-devel make libmnl-devel iptables-devel lsof glibc numactl-devel ncurses-devel systemd-devel groff libgudev libgudev-devel lsb-release popt-devel pkg-config python3-twisted libpcap unbound python3-zope-interface graphviz less iputils tcpdump sysstat qemu-kvm libvirt libguestfs-tools libreswan ipmitool nvme-cli coreutils rsyslog
+RUN yum install -y \
+    wget \
+    kmod \
+    util-linux \
+    sudo \
+    netplan \
+    hostname \
+    openssh-server \
+    iproute \
+    which \
+    git \
+    selinux-policy-devel \
+    diffutils \
+    file \
+    procps-ng \
+    patch \
+    rpm-build \
+    kernel \
+    kernel-devel \
+    kernel-headers \
+    python3 \
+    python3-devel \
+    python3-libs \
+    python3-test \
+    python3-pyelftools \
+    efibootmgr \
+    efivar \
+    grub2 \
+    grub2-efi \
+    grub2-efi-unsigned \
+    shim-unsigned-aarch64 \
+    lvm2 \
+    popt-devel \
+    bc \
+    flex \
+    bison \
+    lm_sensors \
+    ninja-build \
+    meson \
+    cryptsetup \
+    pciutils-devel \
+    python3-sphinx \
+    python3-six \
+    kexec-tools \
+    jq \
+    dbus \
+    libgomp \
+    iana-etc \
+    libgomp-devel \
+    libgcc-devel \
+    libgcc-atomic \
+    libmpc \
+    binutils \
+    libsepol-devel \
+    iptables \
+    glibc-devel \
+    gcc \
+    tcl-devel \
+    automake \
+    libmnl \
+    autoconf \
+    tcl \
+    libnl3-devel \
+    openssl-devel \
+    libstdc++-devel \
+    binutils-devel \
+    libselinux-devel \
+    libnl3 \
+    libdb-devel \
+    make \
+    libmnl-devel \
+    iptables-devel \
+    lsof \
+    glibc \
+    numactl-devel \
+    ncurses-devel \
+    systemd-devel \
+    groff \
+    libgudev \
+    libgudev-devel \
+    lsb-release \
+    popt-devel \
+    pkg-config \
+    python3-twisted \
+    libpcap \
+    unbound \
+    python3-zope-interface \
+    graphviz \
+    less \
+    iputils \
+    tcpdump \
+    sysstat \
+    qemu-kvm \
+    libvirt \
+    libguestfs-tools \
+    libreswan \
+    ipmitool \
+    nvme-cli \
+    coreutils \
+    rsyslog
 
 # Set python3.9 as a default
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 10
-
 RUN /tmp/rebuild_drivers $(/bin/ls -1 /lib/modules/ | head -1)
 RUN /usr/sbin/depmod -a $(/bin/ls -1 /lib/modules/ | head -1) || true
 
-RUN yum install -y ibacm ibutils2 infiniband-diags infiniband-diags-compat libibumad libibverbs libibverbs-utils librdmacm librdmacm-utils libxpmem libxpmem-devel mft mft-oem mlnx-ethtool mlnx-fw-updater mlnx-iproute2 mlnx-libsnap mlx-regex mlxbf-bootctl mlxbf-bootimages mstflint ofed-scripts opensm opensm-devel opensm-libs opensm-static perftest rdma-core rdma-core-devel srp_daemon ucx ucx-cma ucx-devel ucx-ib ucx-knem ucx-rdmacm xpmem mlnx-tools mlnx-dpdk mlnx-dpdk-devel dpcp libvma libvma-utils python3-grpcio python3-protobuf rxp-compiler openvswitch openvswitch-devel python3-openvswitch openvswitch-ipsec mlxbf-bfscripts bf-release
+RUN yum install -y \
+    ibacm \
+    ibutils2 \
+    infiniband-diags \
+    infiniband-diags-compat \
+    libibumad \
+    libibverbs \
+    libibverbs-utils \
+    librdmacm \
+    librdmacm-utils \
+    libxpmem \
+    libxpmem-devel \
+    mft \
+    mft-oem \
+    mlnx-ethtool \
+    mlnx-fw-updater \
+    mlnx-iproute2 \
+    mlnx-libsnap \
+    mlx-regex \
+    mlxbf-bootctl \
+    mlxbf-bootimages \
+    mstflint \
+    ofed-scripts \
+    opensm \
+    opensm-devel \
+    opensm-libs \
+    opensm-static \
+    perftest \
+    rdma-core \
+    rdma-core-devel \
+    srp_daemon \
+    ucx \
+    ucx-cma \
+    ucx-devel \
+    ucx-ib \
+    ucx-knem \
+    ucx-rdmacm \
+    xpmem \
+    mlnx-tools \
+    mlnx-dpdk \
+    mlnx-dpdk-devel \
+    dpcp \
+    libvma \
+    libvma-utils \
+    python3-grpcio \
+    python3-protobuf \
+    rxp-compiler \
+    openvswitch \
+    openvswitch-devel \
+    python3-openvswitch \
+    openvswitch-ipsec \
+    mlxbf-bfscripts \
+    bf-release
 
 RUN /bin/rm -f *rpm
-
 CMD  /root/workspace/create_bfb -k $(/bin/ls -1 /lib/modules/ | head -1)

--- a/bfb-build
+++ b/bfb-build
@@ -26,4 +26,4 @@ docker run -t --privileged -e container=docker \
 	--mount type=bind,source=/proc,target=/proc \
 	bfb_runtime_${DISTRO}${DISTRO_VERSION}
 
-readlink -f *aarch64.bfb
+readlink -f *.bfb

--- a/bfb-build
+++ b/bfb-build
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 
 cd ${0%*/*}
 

--- a/create_bfb
+++ b/create_bfb
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Copyright (c) 2020, Mellanox Technologies
 # All rights reserved.

--- a/create_bfb
+++ b/create_bfb
@@ -141,7 +141,7 @@ ex rm -rf initramfs
 
 initramfs=$WDIR/dump-initramfs-v0
 if [ ! -e /boot/initramfs-${kernel}.img ]; then
-	ex dracut --kver ${kernel} --force --omit-drivers 'mlx4_core mlx4_en' /boot/initramfs-${kernel}.img ${kernel}
+	ex dracut --kver ${kernel} --force --omit-drivers 'mlx4_core mlx4_en' --add-drivers "sdhci-of-dwcmshc dw_mmc-bluefield dw_mmc dw_mmc-pltfm mmc_block mlxbf_tmfifo virtio_console mlx5_core mlx5_ib mlxfw ib_umad nvme" /boot/initramfs-${kernel}.img ${kernel}
 fi
 cp /boot/initramfs-${kernel}.img $initramfs
 
@@ -257,9 +257,9 @@ copy_rpm()
 }
 
 # Copy the content of RPM packages
-for package in  mlxbf-bfscripts util-linux dosfstools e2fsprogs kmod glibc coreutils pciutils usbutils chkconfig mft mft-oem kernel-mft tar which curl openssl $ADDON_RPMS
+for package in  mlxbf-bfscripts util-linux dosfstools e2fsprogs kmod glibc coreutils pciutils usbutils chkconfig mft mft-oem kernel-mft tar which curl openssl nvme-cli mmc-utils $ADDON_RPMS
 do
-	copy_rpm $package
+	copy_rpm $package || true
 done
 
 # Copy tools
@@ -274,7 +274,7 @@ do
 done
 
 sudo depmod -a -b ./ $kernel
-sudo ldconfig -r ./ || true
+sudo ldconfig -r ./
 sudo mkdir -p usr/share/misc/ bin/
 sudo cp /usr/share/misc/pci.ids.gz usr/share/misc/
 # Make sure we can load mlx-bootctl
@@ -305,12 +305,14 @@ cat > etc/init.d/install-mariner << EOF
 #!/bin/bash
 
 insmod /mlx-bootctl.ko > /dev/null 2>&1
+modprobe -a sdhci-of-dwcmshc mlxbf_tmfifo dw_mmc_bluefield mmc_block virtio_console nvme 2>&1 | tee /dev/kmsg
+modprobe -a mlx5_ib mlxfw ib_umad 2>&1 | tee /dev/kmsg
+
 echo
 echo "=================================" | tee /dev/kmsg
 echo "Installing Mariner. Please wait..." | tee /dev/kmsg
 echo "=================================" | tee /dev/kmsg
 
-modprobe -a mlx5_ib ib_uverbs 2>&1 | tee /dev/kmsg
 sleep 5
 
 /bin/sh /mariner/install.sh
@@ -366,10 +368,13 @@ if [ ! -e $CAPSULE ]; then
 fi
 
 boot_args=$(mktemp)
+boot_args2=$(mktemp)
 boot_path=$(mktemp)
 boot_desc=$(mktemp)
 printf "console=ttyAMA1 console=hvc0 console=ttyAMA0 earlycon=pl011,0x01000000 earlycon=pl011,0x01800000 initrd=initramfs" > \
 	"$boot_args"
+printf "console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000 initrd=initramfs" > \
+	"$boot_args2"
 
 printf "VenHw(F019E406-8C9C-11E5-8797-001ACA00BFC4)/Image" > "$boot_path"
 printf "Linux from rshim" > "$boot_desc"
@@ -386,6 +391,7 @@ ex $mkbfb \
 	--image "$vmlinuz" --initramfs "$initramfs" \
 	--capsule "$CAPSULE" \
 	--boot-args-v0 "$boot_args" \
+	--boot-args-v2 "$boot_args2" \
 	--boot-path "$boot_path" \
 	--boot-desc "$boot_desc" \
 	${BFB} /workspace/${MARINER_BFB}

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,6 @@
 PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/mellanox/scripts"
 CHROOT_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-# fspath=$(readlink -f `dirname $0`)
 rshimlog=$(which bfrshlog 2> /dev/null)
 distro="Mariner"
 NIC_FW_UPDATE_DONE=0

--- a/rebuild_drivers
+++ b/rebuild_drivers
@@ -70,7 +70,7 @@ EOF
 # Build and install MLNX_OFED drivers
 ex wget --no-check-certificate --quiet ${BASE_URL}/bluefield/${BF_VERSION}/extras/mlnx_ofed/${MLNX_OFED_VERSION}/MLNX_OFED_SRC-${MLNX_OFED_VERSION}.tgz
 ex tar xzf MLNX_OFED_SRC-${MLNX_OFED_VERSION}.tgz
-ex MLNX_OFED_SRC-${MLNX_OFED_VERSION}/install.pl -U -k $kernel --kernel-extra-args '--with-sf-cfg-drv --without-xdp --without-odp' --kernel-only --disable-kmp --bluefield --with-iser-modules --with-xpmem-modules
+ex MLNX_OFED_SRC-${MLNX_OFED_VERSION}/install.pl -U -k $kernel --kernel-extra-args '--with-sf-cfg-drv --without-xdp --without-odp' --kernel-only --disable-kmp --bluefield --with-xpmem-modules
 
 ex /bin/rm -f /etc/infiniband/vf-net-link-name.sh
 ex cp /usr/share/doc/mlnx-ofa_kernel/vf-net-link-name.sh /etc/infiniband/vf-net-link-name.sh
@@ -96,7 +96,7 @@ do
 			p=`/bin/ls -1 ${WDIR}/${BF_VERSION}/extras/SRPMS/dw_mmc*.src.rpm`
 			;;
 	esac
-	rpmbuild --rebuild -D "debug_package %{nil}" -D "KVERSION $kernel" --define "KMP 0" --define "_topdir ${WDIR}/${BF_VERSION}/extras" $p
+	ex rpmbuild --rebuild -D "debug_package %{nil}" -D "KVERSION $kernel" --define "KMP 0" --define "_topdir ${WDIR}/${BF_VERSION}/extras" $p
 	if [ $? -ne 0 ]; then
 		echo $p >> /tmp/SoC.failed
 	fi

--- a/rebuild_drivers
+++ b/rebuild_drivers
@@ -23,10 +23,11 @@
 #
 ###############################################################################
 
-DOCA_VERSION=2.0.2
-BF_VERSION=4.0.3
-MLNX_OFED_VERSION=23.04-0.5.3.0
+DOCA_VERSION=2.2.0
+BF_VERSION=4.2.0-12855
+MLNX_OFED_VERSION=23.07-0.5.0.0
 WDIR=${WDIR:-/tmp}
+BASE_URL=${BASE_URL:-"https://linux.mellanox.com/public/repo"}
 
 # Execute command w/ echo and exit if it fail
 ex()
@@ -38,11 +39,17 @@ ex()
 	fi
 }
 
+kernel=$1
+
+# Check if existing drivers compiled with the installed kernel
+if [ "$(rpm -qf --queryformat "[%{NAME}]" $(modinfo -n -k $kernel mlx5_core))" == "mlnx-ofa_kernel-modules" ]; then
+	echo "MLNX_OFED drivers compiled for ${kernel}. No need to recompile."
+	exit 0
+fi
+
 if (rpm -q dw_mmc > /dev/null 2>&1); then
 	rpm -e dw_mmc
 fi
-
-kernel=$1
 
 mkdir -p $WDIR
 cd $WDIR
@@ -56,11 +63,12 @@ cat >> /root/.rpmmacros << EOF
 %_datadir   %{_datarootdir}
 %_datarootdir       %{_prefix}/share
 %_includedir       %{_prefix}/include
+%__make       /usr/bin/make
 EOF
 
 
 # Build and install MLNX_OFED drivers
-ex wget --no-check-certificate --quiet https://linux.mellanox.com/public/repo/bluefield/${BF_VERSION}/extras/mlnx_ofed/${MLNX_OFED_VERSION}/MLNX_OFED_SRC-${MLNX_OFED_VERSION}.tgz
+ex wget --no-check-certificate --quiet ${BASE_URL}/bluefield/${BF_VERSION}/extras/mlnx_ofed/${MLNX_OFED_VERSION}/MLNX_OFED_SRC-${MLNX_OFED_VERSION}.tgz
 ex tar xzf MLNX_OFED_SRC-${MLNX_OFED_VERSION}.tgz
 ex MLNX_OFED_SRC-${MLNX_OFED_VERSION}/install.pl -U -k $kernel --kernel-extra-args '--with-sf-cfg-drv --without-xdp --without-odp' --kernel-only --disable-kmp --bluefield --with-iser-modules --with-xpmem-modules
 
@@ -73,18 +81,18 @@ ex cp /usr/share/doc/mlnx-ofa_kernel/82-net-setup-link.rules /etc/udev/rules.d/8
 # find MLNX_OFED_SRC-${MLNX_OFED_VERSION}/RPMS -name '*rpm' -a ! -name '*debuginfo*rpm' -exec rpm -ihv '{}' \;
 
 # Build and install BlueField SoC drivers
-ex wget --quiet --no-check-certificate -r -np -nH --cut-dirs=3 -R "index.html*" https://linux.mellanox.com/public/repo/bluefield/${BF_VERSION}/extras/SRPMS/
+ex wget --quiet --no-check-certificate -r -np -nH --cut-dirs=3 -R "index.html*" ${BASE_URL}/bluefield/${BF_VERSION}/extras/SRPMS/
 mkdir -p ${WDIR}/${BF_VERSION}/extras/{SPECS,RPMS,SOURCES,BUILD}
 
 for p in ${WDIR}/${BF_VERSION}/extras/SRPMS/*.src.rpm
 do
 	case $p in
-		*rshim* | *libpka* | *mlx-OpenIPMI* | *mlxbf-bootctl* | *ipmb-host* | *mlx-cpld* | *gpio* | *pinctrl*)
+		*rshim* | *libpka* | *mlx-OpenIPMI* | *mlxbf-bootctl* | *ipmb-host* | *mlx-cpld*)
 			continue
 			;;
 		*dw_mmc*)
 			/bin/rm -f $p
-			wget  --quiet --no-check-certificate -P ${WDIR}/${BF_VERSION}/extras/SRPMS/ https://linux.mellanox.com/public/repo/bluefield/${BF_VERSION}/extras/5.15/dw_mmc-5.15.36-0.src.rpm
+			wget  --quiet --no-check-certificate -P ${WDIR}/${BF_VERSION}/extras/SRPMS/ ${BASE_URL}/bluefield/${BF_VERSION}/extras/5.15/dw_mmc-5.15.36-0.src.rpm
 			p=`/bin/ls -1 ${WDIR}/${BF_VERSION}/extras/SRPMS/dw_mmc*.src.rpm`
 			;;
 	esac


### PR DESCRIPTION
These changes add support for Bluefield 3.
Output BFB still compatible with Bluefield 2
Add rshim logging during install.
Check for already installed drivers in Mariner before rebuilding.
