### PR TITLE
Remove pinctrl for bluefield3 from build

### DIFF
--- a/rebuild_drivers
+++ b/rebuild_drivers
@@ -87,7 +87,7 @@ mkdir -p ${WDIR}/${BF_VERSION}/extras/{SPECS,RPMS,SOURCES,BUILD}
 for p in ${WDIR}/${BF_VERSION}/extras/SRPMS/*.src.rpm
 do
 	case $p in
-		*rshim* | *libpka* | *mlx-OpenIPMI* | *mlxbf-bootctl* | *ipmb-host* | *mlx-cpld*)
+		*rshim* | *libpka* | *mlx-OpenIPMI* | *mlxbf-bootctl* | *ipmb-host* | *mlx-cpld* | *pinctrl*)
 			continue
 			;;
 		*dw_mmc*)


### PR DESCRIPTION
Remove pinctrl-mlxbf3 from the rebuild drivers script.
Driver failed to build with current version, creating #14 for follow up